### PR TITLE
Use dockerd to check running processes

### DIFF
--- a/usr/share/omvdocker/Utils.php
+++ b/usr/share/omvdocker/Utils.php
@@ -76,7 +76,7 @@ class OMVModuleDockerUtil
      */
     public static function stopDockerService()
     {
-        $cmd = 'ps aux | grep "/usr/bin/docker daemon" | grep -v grep | wc -l';
+        $cmd = 'ps aux | grep "/usr/bin/dockerd" | grep -v grep | wc -l';
         OMVUtil::exec($cmd, $out, $res);
 
         while ($out[0] > 0) {
@@ -85,7 +85,7 @@ class OMVModuleDockerUtil
             OMVUtil::exec($cmd, $out, $res);
             unset($out);
             sleep(1);
-            $cmd = 'ps aux | grep "/usr/bin/docker daemon" | grep -v grep | wc -l';
+            $cmd = 'ps aux | grep "/usr/bin/dockerd" | grep -v grep | wc -l';
             OMVUtil::exec($cmd, $out, $res);
         }
     }


### PR DESCRIPTION
Command 'docker daemon' has been removed from newer Docker versions. Use 'dockerd' to run the daemon directly.