### PR TITLE
New features for the docker plugin

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+openmediavault-docker-gui (3.1.9) UNRELEASED; urgency=medium
+
+  * Add restart policy menu. Includes always, on-failure, unless-stopped.
+  * Add basic macvlan support in the gui to select the network and add the ip address.
+  * Retain the extra arguments on modify container action. 
+  * Add clear log button. 
+
+ -- root <root@localhost.localdomain>  Thu, 08 Jun 2017 23:48:05 +0100
+
 openmediavault-docker-gui (3.1.8) stable; urgency=low
 
   * Allow armhf arch and fetch arch-specific dockerlist

--- a/usr/share/omvdocker/Container.php
+++ b/usr/share/omvdocker/Container.php
@@ -1,3 +1,4 @@
+
 <?php
 /**
  * Copyright (c) 2015-2017 OpenMediaVault Plugin Developers
@@ -18,11 +19,13 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
+
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 require_once "Exception.php";
+require_once "Utils.php";
 
 /**
  * Class for managing Docker containers
@@ -58,7 +61,7 @@ class OMVModuleDockerContainer
     /**
      * Time when container was created
      *
-     * @var 	string $_created
+     * @var     string $_created
      * @access private
      */
     private $_created;
@@ -66,7 +69,7 @@ class OMVModuleDockerContainer
     /**
      * Command that is started by the container
      *
-     * @var 	string $_command
+     * @var     string $_command
      * @access private
      */
     private $_command;
@@ -74,7 +77,7 @@ class OMVModuleDockerContainer
     /**
      * Status of the container
      *
-     * @var 	string $_status
+     * @var     string $_status
      * @access private
      */
     private $_status;
@@ -82,7 +85,7 @@ class OMVModuleDockerContainer
     /**
      * State of the container
      *
-     * @var 	string $_state
+     * @var     string $_state
      * @access private
      */
     private $_state;
@@ -90,7 +93,7 @@ class OMVModuleDockerContainer
     /**
      * Ports mapped to the container
      *
-     * @var 	array $_ports
+     * @var     array $_ports
      * @access private
      */
     private $_ports;
@@ -98,7 +101,7 @@ class OMVModuleDockerContainer
     /**
      * Network mode of the container
      *
-     * @var 	string $_networkMode
+     * @var     string $_networkMode
      * @access private
      */
     private $_networkMode;
@@ -106,7 +109,7 @@ class OMVModuleDockerContainer
     /**
      * Privileged mode of the container
      *
-     * @var 	bool $_privileged
+     * @var     bool $_privileged
      * @access private
      */
     private $_privileged;
@@ -114,15 +117,23 @@ class OMVModuleDockerContainer
     /**
      * Restart policy of the container
      *
-     * @var 	string $_restartPolicy
+     * @var     string $_restartPolicy
      * @access private
      */
     private $_restartPolicy;
 
     /**
+     * Max number of retries for on-failure restart policy
+     *
+     * @var     string $_maxRetries
+     * @access private
+     */
+    private $_maxRetries;
+
+    /**
      * Environment variables defined in the container
      *
-     * @var 	array $_envVars
+     * @var     array $_envVars
      * @access private
      */
     private $_envVars;
@@ -130,7 +141,7 @@ class OMVModuleDockerContainer
     /**
      * ID of the image the container is created from
      *
-     * @var 	string $_imageId
+     * @var     string $_imageId
      * @access private
      */
     private $_imageId;
@@ -138,7 +149,7 @@ class OMVModuleDockerContainer
     /**
      * Port bindings in the container
      *
-     * @var 	array $_portBindings
+     * @var     array $_portBindings
      * @access private
      */
     private $_portBindings;
@@ -146,7 +157,7 @@ class OMVModuleDockerContainer
     /**
      * Bind mounts in the container
      *
-     * @var 	array $_bindMounts
+     * @var     array $_bindMounts
      * @access private
      */
     private $_bindMounts;
@@ -154,7 +165,7 @@ class OMVModuleDockerContainer
     /**
      * Name of the container
      *
-     * @var 	string $_names
+     * @var     string $_names
      * @access private
      */
     private $_names;
@@ -162,7 +173,7 @@ class OMVModuleDockerContainer
     /**
      * Does the container have any mountpoints
      *
-     * @var 	bool $_hasMounts
+     * @var     bool $_hasMounts
      * @access private
      */
     private $_hasMounts;
@@ -186,7 +197,7 @@ class OMVModuleDockerContainer
     /**
      * Is the container syncing it's time with the host
      *
-     * @var 	bool $_timeSync
+     * @var     bool $_timeSync
      * @access private
      */
     private $_timeSync;
@@ -243,11 +254,22 @@ class OMVModuleDockerContainer
             }
         }
         $this->_networkMode = $containerData->HostConfig->NetworkMode;
+
+        $macvlans = OMVModuleDockerUtil::getMacVlanNetworks(
+            $apiPort
+        );
+        $macvlans = array_column($macvlans,'name');
+        $macvlan_network = $containerData->HostConfig->NetworkMode;
         if (strcmp($this->_networkMode, "default") === 0) {
             $this->_networkMode = "bridge";
+        } elseif (in_array($macvlan_network, $macvlans)) {
+            $this->_networkMode = "macvlan";
+            $this->_macVlanContainerNetwork = $containerData->HostConfig->NetworkMode;
+            $this->_macVlanContainerIpAddress = $containerData->NetworkSettings->Networks->$macvlan_network->IPAddress;
         }
         $this->_privileged = $containerData->HostConfig->Privileged;
         $this->_restartPolicy = $containerData->HostConfig->RestartPolicy->Name;
+        $this->_maxRetries = $containerData->HostConfig->RestartPolicy->MaximumRetryCount;
         $this->_envVars = array();
         if (isset($containerData->Config->Env)) {
             foreach ($containerData->Config->Env as $eVar) {
@@ -320,6 +342,17 @@ class OMVModuleDockerContainer
                 array_push($this->_volumesFrom, array("from" => $volume));
             }
         }
+
+        $this->_extraArgs = "";
+        if (isset($containerData->Config->Labels->omv_docker_extra_args)) {
+            $this->_extraArgs = $containerData->Config->Labels->omv_docker_extra_args;
+        }
+
+        $this->_logPath = $containerData->LogPath;
+        //$logPath = $containerData->LogPath;
+        //print $logPath;
+    
+
         $this->_hostName = "";
         if (!(strcmp($containerData->Config->Hostname, "") === 0)) {
             $this->_hostName .= $containerData->Config->Hostname;
@@ -339,6 +372,7 @@ class OMVModuleDockerContainer
     {
         return substr($this->_id, 0, 12);
     }
+
 
     /**
      * Get the image the conatiner is mapped to
@@ -440,6 +474,17 @@ class OMVModuleDockerContainer
     }
 
     /**
+     * Get the max number of retries for on-failure policy
+     *
+     * @return string $_maxRetries
+     * @access public
+     */
+    public function getMaxRetries()
+    {
+        return $this->_maxRetries;
+    }
+
+    /**
      * Get the environment variables defined in the container
      *
      * @return array $_envVars
@@ -536,6 +581,50 @@ class OMVModuleDockerContainer
     public function syncsTime()
     {
         return $this->_timeSync;
+    }
+
+    /**
+     * Get the macvlan network name of the container
+     *
+     * @return string $_macVlanContainerNetwork
+     * @access public
+     */
+    public function getMacVlanContainerNetwork()
+    {
+        return $this->_macVlanContainerNetwork;
+    }
+
+    /**
+     * Get the macvlan network ip address of the container
+     *
+     * @return string $_macVlanContainerIpAddress
+     * @access public
+     */
+    public function getMacVlanContainerIpAddress()
+    {
+        return $this->_macVlanContainerIpAddress;
+    }
+
+    /**
+     * Get the value of the label property called omv_docker_extra_args use to stored the extra args
+     *
+     * @return string $_extraArgs
+     * @access public
+     */
+    public function getExtraArgs()
+    {
+        return $this->_extraArgs;
+    }
+
+    /**
+     * Get the value of the property LogPath from container info
+     *
+     * @return string $_logPath
+     * @access public
+     */
+    public function getLogPath()
+    {
+        return $this->_logPath;
     }
 
 }

--- a/usr/share/omvdocker/Image.php
+++ b/usr/share/omvdocker/Image.php
@@ -150,7 +150,7 @@ class OMVModuleDockerImage
         $this->_envVars = array();
         if (isset($imageData->Config->Env)) {
             foreach ($imageData->Config->Env as $eVar) {
-                $eVarAry = explode("=", $eVar,1);
+                $eVarAry = explode("=", $eVar,2);
                 $this->_envVars[$eVarAry[0]] = $eVarAry[1];
             }
         }

--- a/usr/share/omvdocker/Image.php
+++ b/usr/share/omvdocker/Image.php
@@ -150,7 +150,7 @@ class OMVModuleDockerImage
         $this->_envVars = array();
         if (isset($imageData->Config->Env)) {
             foreach ($imageData->Config->Env as $eVar) {
-                $eVarAry = explode("=", $eVar);
+                $eVarAry = explode("=", $eVar,1);
                 $this->_envVars[$eVarAry[0]] = $eVarAry[1];
             }
         }

--- a/usr/share/omvdocker/Utils.php
+++ b/usr/share/omvdocker/Utils.php
@@ -130,7 +130,7 @@ class OMVModuleDockerUtil
         //get the macvlan name
             $tmp=array(
                 "name"      => $item->Name,
-                "subnet"    => $item->IPAM->Config[0]->Subnet);
+                "description"    => $item->Name . " (" . $item->IPAM->Config[0]->Subnet . ")");
         //pass the macvlan names to an array
             array_push($objects, $tmp);
         }

--- a/usr/share/omvdocker/Utils.php
+++ b/usr/share/omvdocker/Utils.php
@@ -110,6 +110,35 @@ class OMVModuleDockerUtil
     }
 
     /**
+     * Returns an array with maclvan network names and their subnets
+     *
+     * @param int  $apiPort     Network port to use in API call
+     * @param bool $incDangling Flag to filter dangling images (not used)
+     *
+     * @return array $objects An array with macvlan names and subnets
+     *
+     */
+    public static function getMacVlanNetworks($apiPort, $incDangling)
+    {
+        $objects=array();
+        $url = "http://localhost:" . $apiPort . "/networks/?filters=%7B%22driver%22%3A%7B%22macvlan%22%3Atrue%7D%7D";
+        $response = OMVModuleDockerUtil::doApiCall($url);
+        $macvlan_data = json_decode($response);
+        $objects = array();
+        //Iterate over each macvlan object that the api returns
+        foreach ($macvlan_data as $item) {
+        //get the macvlan name
+            $tmp=array(
+                "name"      => $item->Name,
+                "subnet"    => $item->IPAM->Config[0]->Subnet);
+        //pass the macvlan names to an array
+            array_push($objects, $tmp);
+        }
+        return $objects;
+    }
+
+
+    /**
      * Returns an array with Image objects on the system
      *
      * @param int  $apiPort     Network port to use in API call
@@ -264,7 +293,10 @@ class OMVModuleDockerUtil
                 "name" => $container->getName(),
                 "privileged" => $container->getPrivileged(),
                 "restartpolicy" => $container->getRestartPolicy(),
+                "maxretries" => $container->getMaxRetries(),
                 "networkmode" => ucfirst($container->getNetworkMode()),
+                "macvlan_network" => $container->getMacVlanContainerNetwork(),
+                "macvlan_ipaddress" => $container->getMacVlanContainerIpAddress(),
                 "envvars" => $image->getEnvVars(),
                 "cenvvars" => $container->getEnvironmentVariables(),
                 "exposedports" => $image->getPorts(),
@@ -273,6 +305,7 @@ class OMVModuleDockerUtil
                 "ports" => $ports,
                 "hasmounts" => $container->hasMounts(),
                 "volumesfrom" => $container->getVolumesFrom(),
+                "extraargs" => $container->getExtraArgs(),
                 "hostname" => $container->getHostName(),
                 "timesync" => $container->syncsTime(),
                 "imagevolumes" => $image->getVolumes());
@@ -317,6 +350,8 @@ class OMVModuleDockerUtil
                 $state = "stopped";
             }
 
+            $extraargs = $item->Labels->omv_docker_extra_args; 
+
             array_push(
                 $objects,
                 array(
@@ -330,7 +365,8 @@ class OMVModuleDockerUtil
                         $now,
                         date("c", $item->Created)
                     ) . " ago",
-                    "state" => $state
+                    "state" => $state,
+                    "extraargs" => $extraargs
                 )
             );
         }

--- a/usr/share/openmediavault/engined/rpc/docker.inc
+++ b/usr/share/openmediavault/engined/rpc/docker.inc
@@ -128,6 +128,8 @@ class OMVRpcServiceDocker extends ServiceAbstract
         $this->registerMethod("getDockerRepo");
 
         $this->registerMethod("set");
+        $this->registerMethod("getMacVlan");
+        $this->registerMethod("clearLog");
     }
 
     public function set($params, $context)
@@ -147,6 +149,30 @@ class OMVRpcServiceDocker extends ServiceAbstract
         }
         return $arch;
     }
+
+    /**
+     * Get all Docker images
+     *
+     * @param array  $params  An associative array with all RPC call parameters
+     * @param string $context The context of the user maing the RPC call
+     *
+     * @return array $objects An array with all docker macvlan network names and their respective subnet
+     */
+    public function getMacVlan($params, $context)
+    {
+        $this->validateMethodContext(
+            $context,
+            array("role" => OMV_ROLE_ADMINISTRATOR)
+        );
+        $settings=$this->database->getAssoc($this->dataModelPath);
+
+        $objects = array();
+        $objects = OMVModuleDockerUtil::getMacVlanNetworks(
+            $settings['apiPort']
+        );
+        return $objects;
+    }
+
 
     /**
      * Get all Docker images
@@ -424,9 +450,30 @@ class OMVRpcServiceDocker extends ServiceAbstract
         $cmd = "docker run -d ";
 
         //Check if restart checkbox is enabled
-        if ($params['restart']) {
-            $cmd .= "--restart=always ";
+        //if ($params['restartpolicy']) {
+        //    $cmd .= "--restart=always ";
+        //}
+
+        switch ($params['restartpolicy']) {
+            case "always":
+                $cmd .= "--restart=always ";
+                break;
+            case "no":
+                $cmd .= "--restart=no ";
+                break;
+            case "unless-stopped":
+                $cmd .= "--restart=unless-stopped ";
+                break;
+            case "on-failure":
+                if (isset($params['maxretries'])) {
+                    $cmd .= "--restart=on-failure:" . $params['maxretries'] . " ";
+                } elseif (!isset($params['maxretries'])) {
+                    $cmd .= "--restart=on-failure ";
+                }
+                break;
         }
+
+
 
         //Check if privileged checkbox is enabled
         if ($params['privileged']) {
@@ -463,6 +510,9 @@ class OMVRpcServiceDocker extends ServiceAbstract
             break;
         case "None":
             $cmd .= "--net=none ";
+            break;
+        case "Macvlan":
+            $cmd .= "--net=" . $params['macvlan_network'] . " " . "--ip=" . $params['macvlan_ipaddress'] . " ";
             break;
         }
 
@@ -513,6 +563,8 @@ class OMVRpcServiceDocker extends ServiceAbstract
         //Check if extra arguments are supplied
         $extraArgs = trim($params['extraArgs']);
         if (!(strcmp($extraArgs, "") === 0)) {
+            //Store the extra command parameters in a container label as omv_docker_extra_args
+            $cmd .= "--label omv_docker_extra_args=" . "\"" . $extraArgs . "\" ";
             $cmd .= $extraArgs . " ";
         }
 
@@ -547,10 +599,14 @@ class OMVRpcServiceDocker extends ServiceAbstract
             $settings['apiPort']
         );
 
-        $restart = false;
-        if (strcmp($container->getRestartPolicy(), "always") === 0) {
-            $restart = true;
-        }
+        $restartpolicy = $container->getRestartPolicy();
+        $maxretries = $container->getMaxRetries();
+        //if (strcmp($container->getRestartPolicy(), "always") === 0) {
+         //   $restart = true;
+        //}
+        $networkMode = $container->getNetworkMode();
+        $macvlan_network = $container->getMacVlanContainerNetwork();
+        $macvlan_ipaddress = $container->getMacVlanContainerIpAddress();
         $portForwards = array();
         foreach ($container->getPortBindings() as $binding) {
             $customPort = "";
@@ -596,15 +652,19 @@ class OMVRpcServiceDocker extends ServiceAbstract
         }
 
         $old_params = array(
-            "restart" => $restart,
+            "restartpolicy" => $restartpolicy,
+            "maxretries" => $maxretries,
             "privileged" => $container->getPrivileged(),
             "timeSync" => $container->syncsTime(),
             "networkMode" => ucfirst($container->getNetworkMode()),
+            "macvlan_network" => $container->getMacVlanContainerNetwork(),
+            "macvlan_ipaddress" => $container->getMacVlanContainerIpAddress(),
             "portForwards" => $portForwards,
             "hostName" => $container->getHostName(),
             "envVars" => $envVars,
             "bindMounts" => $bindMounts,
             "volumes" => $container->getVolumesFrom(),
+            "extraargs" => $container->getExtraArgs(),
             "containerName" => $container->getName(),
             "image" => $container->getImage()
         );
@@ -712,6 +772,31 @@ class OMVRpcServiceDocker extends ServiceAbstract
         $cmd = "docker rm " . $params['id'] . " 2>&1";
         $process = new Process($cmd);
         $process->execute();
+    }
+
+    /**
+     * Clear the log on one or multiple containers
+     *
+     * @param array  $params  An associative array with all RPC call parameters
+     * @param string $context The context of the user maing the RPC call
+     *
+     * @return void
+     */
+    public function clearLog($params, $context)
+    {
+        $this->validateMethodContext(
+            $context,
+            array("role" => OMV_ROLE_ADMINISTRATOR)
+        );
+        $settings=$this->database->getAssoc($this->dataModelPath);
+        $ids = explode(" ", $params['id']);
+        foreach ($ids as $id) {
+            $container = OMVModuleDockerUtil::getContainer($id, $settings['apiPort']);
+            $logpath = $container->getLogPath();
+            $cmd = "cat /dev/null >" . $logpath;
+            $process = new Process($cmd);
+            $process->execute();
+        }
     }
 
     /**
@@ -904,7 +989,10 @@ class OMVRpcServiceDocker extends ServiceAbstract
             "name" => $container->getName(),
             "privileged" => $container->getPrivileged(),
             "restartpolicy" => $container->getRestartPolicy(),
+            "maxretries" => $container->getMaxRetries(),
             "networkmode" => ucfirst($container->getNetworkMode()),
+            "macvlan_network" => $container->getMacVlanContainerNetwork(),
+            "macvlan_ipaddress" => $container->getMacVlanContainerIpAddress(),
             "envvars" => $image->getEnvVars(),
             "cenvvars" => $container->getEnvironmentVariables(),
             "exposedports" => $image->getPorts(),
@@ -913,6 +1001,7 @@ class OMVRpcServiceDocker extends ServiceAbstract
             "ports" => $ports,
             "hasmounts" => $container->hasMounts(),
             "volumesfrom" => $container->getVolumesFrom(),
+            "extraargs" => $container->getExtraArgs(),
             "hostname" => $container->getHostName(),
             "timesync" => $container->syncsTime(),
             "imagevolumes" => $image->getVolumes()

--- a/var/www/openmediavault/js/omv/module/admin/service/docker/ContainerGrid.js
+++ b/var/www/openmediavault/js/omv/module/admin/service/docker/ContainerGrid.js
@@ -165,32 +165,38 @@ Ext.define("OMV.module.admin.service.docker.ContainerGrid", {
             handler: Ext.Function.bind(me.onCreateButton, me, [ me ]),
             scope: me
         },{
-            id: me.getId() + "-start",
-            xtype: "button",
-            text: _("Start"),
+            xtype: "splitbutton",
+            text: "Start",
             icon: "images/play.png",
             iconCls: Ext.baseCSSPrefix + "btn-icon-16x16",
-            disabled: true,
-            handler: Ext.Function.bind(me.onStartButton, me, [ me ]),
-            scope: me
-        },{
-            id: me.getId() + "-stop",
-            xtype: "button",
-            text: _("Stop"),
-            icon: "images/docker_stop.png",
-            iconCls: Ext.baseCSSPrefix + "btn-icon-16x16",
-            disabled: true,
-            handler: Ext.Function.bind(me.onStopButton, me, [ me ]),
-            scope: me
-        },{
-            id: me.getId() + "-restart",
-            xtype: "button",
-            text: _("Restart"),
-            icon: "images/undo.png",
-            iconCls: Ext.baseCSSPrefix + "btn-icon-16x16",
-            disabled: true,
-            handler: Ext.Function.bind(me.onRestartButton, me, [ me ]),
-            scope: me
+            scope: me,
+            menu: Ext.create("Ext.menu.Menu", {
+                items: [{
+                    id: me.getId() + "-start",
+                    text: _("Start"),
+                    disabled: true,
+                    iconCls: Ext.baseCSSPrefix + "btn-icon-16x16",
+                    icon: "images/play.png",
+                    handler: Ext.Function.bind(me.onStartButton, me, [ me ]),
+                    scope: me
+                },{
+                    id: me.getId() + "-stop",
+                    text: _("Stop"),
+                    disabled: true,
+                    iconCls: Ext.baseCSSPrefix + "btn-icon-16x16",
+                    icon: "images/docker_stop.png",
+                    handler: Ext.Function.bind(me.onStopButton, me, [ me ]),
+                    scope: me
+                },{
+                    id: me.getId() + "-restart",
+                    text: _("Restart"),
+                    disabled: true,
+                    iconCls: Ext.baseCSSPrefix + "btn-icon-16x16",
+                    icon: "images/undo.png",
+                    handler: Ext.Function.bind(me.onRestartButton, me, [ me ]),
+                    scope: me
+                }]
+            })
         },{
             id: me.getId() + "-copy",
             xtype: "button",

--- a/var/www/openmediavault/js/omv/module/admin/service/docker/ContainerGrid.js
+++ b/var/www/openmediavault/js/omv/module/admin/service/docker/ContainerGrid.js
@@ -100,6 +100,13 @@ Ext.define("OMV.module.admin.service.docker.ContainerGrid", {
         sortable: true,
         stateId: 'state',
         filter: 'list'
+    },{
+        xtype: "textcolumn",
+        text: _("EXTRA ARGUMENTS"),
+        dataIndex: 'extraargs',
+        sortable: false,
+        stateId: 'extraargs',
+        filter: 'string'
     }],
 
     initComponent: function() {
@@ -117,7 +124,10 @@ Ext.define("OMV.module.admin.service.docker.ContainerGrid", {
                         { name: "state", type: "string" },
                         { name: "ports", type: "string" },
                         { name: "networkmode", type: "string" },
+                        { name: "macvlan_ipaddress", type: "string"},
+                        { name: "macvlan_network", type: "string"},
                         { name: "restartpolicy", type: "string" },
+                        { name: "maxretries", type: "integer"},
                         { name: "privileged", type: "boolean" },
                         { name: "exposedports", type: "array" },
                         { name: "envvars", type: "array" },
@@ -125,6 +135,7 @@ Ext.define("OMV.module.admin.service.docker.ContainerGrid", {
                         { name: "portbindings", type: "array" },
                         { name: "name", type: "string" },
                         { name: "volumesfrom", type: "array" },
+                        { name: "extraargs", type: "string"},
                         { name: "hostname", type: "string" },
                         { name: "timesync", type: "boolean" },
                         { name: "imagevolumes", type: "array" }
@@ -252,6 +263,16 @@ Ext.define("OMV.module.admin.service.docker.ContainerGrid", {
             hidden: false,
             handler: Ext.Function.bind(me.onRefreshButton, me, [ me ]),
             scope: me
+        },{
+            id: me.getId() + "-clearlog",
+            xtype: "button",
+            text: _("Clear Log"),
+            icon: "images/trashcan.png",
+            iconCls: Ext.baseCSSPrefix + "btn-icon-16x16",
+            disabled: true,
+            hidden: false,
+            handler: Ext.Function.bind(me.onClearLogButton, me, [ me ]),
+            scope: me
         }]
     },
 
@@ -259,7 +280,7 @@ Ext.define("OMV.module.admin.service.docker.ContainerGrid", {
         var me = this;
         if(me.hideTopToolbar)
             return;
-        var tbarBtnName = [ "create", "start", "stop", "restart", "copy", "modify", "details", "execute", "commit", "logs", "delete", "refresh" ];
+        var tbarBtnName = [ "create", "start", "stop", "restart", "copy", "modify", "details", "execute", "commit", "logs", "delete", "refresh", "clearlog" ];
         var tbarBtnDisabled = {
             "create": false,
             "start": false,
@@ -273,7 +294,8 @@ Ext.define("OMV.module.admin.service.docker.ContainerGrid", {
             "commit": false,
             "logs": false,
             "delete": false,
-            "refresh": false
+            "refresh": false,
+            "clearlog": false
         };
         // Enable/disable buttons depending on the number of selected rows.
         if(records.length <= 0) {
@@ -481,6 +503,45 @@ Ext.define("OMV.module.admin.service.docker.ContainerGrid", {
         });
     },
 
+    onClearLogButton: function() {
+        var me = this;
+        var sm = me.getSelectionModel();
+        var selRecords = sm.getSelection();
+        var record = selRecords[0];
+        var index;
+        var idList = "";
+        for(i = 0; i < selRecords.length; i++) {
+            if(i === 0) {
+                idList = selRecords[i].get("id");
+            } else {
+                idList = idList + " " + selRecords[i].get("id");
+            }
+        }
+        OMV.Rpc.request({
+            scope: me,
+            callback: function(id, success, response) {
+                sm.deselectAll();
+                me.store.load({
+                    scope: me,
+                    callback: function(records, operation, success) {
+                        for(i = 0; i < selRecords.length; i++) {
+                            index = me.store.find('name', selRecords[i].get("name"));
+                            sm.select(index, true);
+                        }
+                    }
+                });
+            },
+            relayErrors: false,
+            rpcData: {
+                service: "Docker",
+                method: "clearLog",
+                params: {
+                    id: idList
+                }
+            }
+        });
+    },
+
     onDetailsButton: function() {
         var me = this;
         var sm = me.getSelectionModel();
@@ -543,15 +604,17 @@ Ext.define("OMV.module.admin.service.docker.ContainerGrid", {
                 var me = this;
 
                 return [{
-                    xtype: "textareafield",
+                    // xtype: "textareafield",
+                    xtype: "textarea",
                     name: "logs",
                     grow: false,
                     height: 620,
                     readOnly: true,
-                    fieldStyle: {
-                        fontFamily: "courier",
-                        fontSize: "12px"
-                    }
+                    cls: "x-form-textarea-monospaced"
+//                    fieldStyle: {
+  //                      fontFamily: "courier",
+    //                    fontSize: "12px"
+      //              }
                 }];
             }
         }).show();
@@ -625,12 +688,16 @@ Ext.define("OMV.module.admin.service.docker.ContainerGrid", {
                             ports: response["exposedports"],
                             envvars: response["envvars"],
                             restartpolicy: response["restartpolicy"],
+                            maxretries: response["maxretries"],
                             privileged: response["privileged"],
                             networkmode: response["networkmode"],
+                            macvlan_network: response["macvlan_network"],
+                            macvlan_ipaddress: response["macvlan_ipaddress"],
                             portbindings: response["portbindings"],
                             bindmounts: response["bindmounts"],
                             cenvvars: response["cenvvars"],
                             copyVolumes: response["volumesfrom"],
+                            extraargs: response["extraargs"],
                             hostname: response["hostname"],
                             timesync: response["timesync"],
                             imagevolumes: response["imagevolumes"]
@@ -690,8 +757,11 @@ Ext.define("OMV.module.admin.service.docker.ContainerGrid", {
                                                     ports: response["exposedports"],
                                                     envvars: response["envvars"],
                                                     restartpolicy: response["restartpolicy"],
+                                                    maxretries: response["maxretries"],
                                                     privileged: response["privileged"],
                                                     networkmode: response["networkmode"],
+                                                    macvlan_ipaddress: response["macvlan_ipaddress"],
+                                                    macvlan_network: response["macvlan_network"],
                                                     portbindings: response["portbindings"],
                                                     bindmounts: response["bindmounts"],
                                                     cenvvars: response["cenvvars"],
@@ -699,6 +769,7 @@ Ext.define("OMV.module.admin.service.docker.ContainerGrid", {
                                                     hostname: response["hostname"],
                                                     timesync: response["timesync"],
                                                     imagevolumes: response["imagevolumes"],
+                                                    extraargs: response["extraargs"],
                                                     name: response["name"],
                                                     cid: response["id"],
                                                     action: "modify"
@@ -729,13 +800,17 @@ Ext.define("OMV.module.admin.service.docker.ContainerGrid", {
                                         ports: response["exposedports"],
                                         envvars: response["envvars"],
                                         restartpolicy: response["restartpolicy"],
+                                        maxretries: response["maxretries"],
                                         privileged: response["privileged"],
                                         networkmode: response["networkmode"],
+                                        macvlan_network: response["macvlan_network"],
+                                        macvlan_ipaddress: response["macvlan_ipaddress"],
                                         portbindings: response["portbindings"],
                                         bindmounts: response["bindmounts"],
                                         cenvvars: response["cenvvars"],
                                         copyVolumes: response["volumesfrom"],
                                         hostname: response["hostname"],
+                                        extraargs: response["extraargs"],
                                         timesync: response["timesync"],
                                         imagevolumes: response["imagevolumes"],
                                         name: response["name"],

--- a/var/www/openmediavault/js/omv/module/admin/service/docker/RunContainer.js
+++ b/var/www/openmediavault/js/omv/module/admin/service/docker/RunContainer.js
@@ -268,13 +268,14 @@ Ext.define("OMV.module.admin.service.docker.RunContainer", {
                     fieldLabel: _("Select macvlan network"),
                     name: "macvlan_network",
                     queryMode: "local",
-                    displayField: 'name',
+                    displayField: 'description',
                     emptyText: _("Select a macvlan network ..."),
                     store: Ext.create("OMV.data.Store", {
                         autoLoad: true,
                         model: OMV.data.Model.createImplicit({
                             fields: [
-                                { name: "devicename", type: "string" }
+                                { name: "name", type: "string" },
+                                { name: "description", type: "string" }
                             ]
                         }),
                         proxy: {
@@ -285,6 +286,7 @@ Ext.define("OMV.module.admin.service.docker.RunContainer", {
                             }
                         },
                     }),
+                    valueField: "name",
                     allowBlank: false,
                     forceSelection: true
                 },{


### PR DESCRIPTION
- Add basic macvlan support, you can choose from existing macvlan networks. Macvlan networks still need to be managed by cli
- Add clear log button.
- Add full restart policy options
- Fix incorrect variable parsing from images (plexmediaserver url issue[https://forum.openmediavault.org/index.php/Thread/18655-Docker-GUI-Failure-to-fully-enumerate-Environment-Variable/](url)
- The modify/copy container now retains the extra arguments fields. This only works from this version onwards. Existing containers won't be able to be modified/copied and retain those extra options