### PR TITLE
Logofix

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+openmediavault-docker-gui (4.0.2) UNRELEASED; urgency=medium
+
+  * Fix for broken logo URLs
+
+ -- OpenMediaVault Plugin Developers <plugins@omv-extras.org>  Fri, 12 Jan 2018 19:25:10 +0100
+
 openmediavault-docker-gui (4.0.1) stable; urgency=low
 
   * Remove rc.local code
@@ -14,7 +20,7 @@ openmediavault-docker-gui (4.0) stable; urgency=low
 
 openmediavault-docker-gui (3.1.10) stable; urgency=medium
 
-  * Move from docker-engine to docker-ce package 
+  * Move from docker-engine to docker-ce package
 
  -- OpenMediaVault Plugin Developers <plugins@omv-extras.org>  Thu, 20 Jul 2017 20:42:25 +0200
 
@@ -22,12 +28,12 @@ openmediavault-docker-gui (3.1.9) stable; urgency=medium
 
   * Add restart policy menu. Includes always, on-failure, unless-stopped.
   * Add basic macvlan support in the gui to select the network and add the ip address.
-  * Retain the extra arguments on modify container action. 
-  * Add clear log button. 
-  * Add tab for networks management 
+  * Retain the extra arguments on modify container action.
+  * Add clear log button.
+  * Add tab for networks management
   * Add services indicator
   * Various UI fixes
-  * Use dockerd for daemon startup 
+  * Use dockerd for daemon startup
 
  -- OpenMediaVault Plugin Developers <plugins@omv-extras.org>  Thu, 20 Jul 2017 20:34:31 +0200
 
@@ -102,7 +108,7 @@ openmediavault-docker-gui (3.0.8) stable; urgency=low
 
 openmediavault-docker-gui (3.0.7) stable; urgency=medium
 
-  * Bug fix to Image backend 
+  * Bug fix to Image backend
   * Bug fix to Container backend
   * Bug fix for networking mode not properly detected
 
@@ -111,7 +117,7 @@ openmediavault-docker-gui (3.0.7) stable; urgency=medium
 openmediavault-docker-gui (3.0.6) stable; urgency=medium
 
   * Bug fixes to container and image backend
-  * Rewrite to improve container and image listing performance 
+  * Rewrite to improve container and image listing performance
   * Fix for Image ID changes introduced in docker-engine 1.10
   * Add dependency on docker-engine >= 1.10
 
@@ -127,13 +133,13 @@ openmediavault-docker-gui (3.0.5) stable; urgency=medium
 openmediavault-docker-gui (3.0.4) stable; urgency=medium
 
   * Add timestamp to image object
-  * Make it possible to modify running container 
+  * Make it possible to modify running container
 
  -- OpenMediaVault Plugin Developers <plugins@omv-extras.org>  Tue, 12 Jan 2016 13:29:22 +0100
 
 openmediavault-docker-gui (3.0.3) stable; urgency=medium
 
-  * Minor tweaks to the repo tab 
+  * Minor tweaks to the repo tab
   * Add logos to the linuxserver.io docker images
   * Add php5-imagick dependancy
   * Make it possible to edit port forwarding rows
@@ -175,7 +181,7 @@ openmediavault-docker-gui (3.0.0) stable; urgency=low
 
 openmediavault-docker-gui (0.2.21) stable; urgency=low
 
-  * Add support for container logs 
+  * Add support for container logs
 
  -- OpenMediaVault Plugin Developers <plugins@omv-extras.org>  Wed, 30 Dec 2015 21:42:22 +0100
 
@@ -252,19 +258,19 @@ openmediavault-docker-gui (0.2.11) unstable; urgency=low
 
 openmediavault-docker-gui (0.2.10) unstable; urgency=low
 
-  * Create folder required for base path relocation 
+  * Create folder required for base path relocation
 
  -- OpenMediaVault Plugin Developers <plugins@omv-extras.org>  Wed, 02 Sep 2015 18:40:19 +0200
 
 openmediavault-docker-gui (0.2.9) unstable; urgency=low
 
-  * Use bind mounts to relocate base path 
+  * Use bind mounts to relocate base path
 
  -- OpenMediaVault Plugin Developers <plugins@omv-extras.org>  Wed, 02 Sep 2015 16:56:37 +0200
 
 openmediavault-docker-gui (0.2.8) unstable; urgency=low
 
-  * Remove noexec option from fstab when relocating base path 
+  * Remove noexec option from fstab when relocating base path
 
  -- OpenMediaVault Plugin Developers <plugins@omv-extras.org>  Tue, 01 Sep 2015 22:48:39 +0200
 
@@ -291,11 +297,11 @@ openmediavault-docker-gui (0.2.4) unstable; urgency=low
 
   * Made it possible to create data containers
   * More PHP code fixes to follow coding standards
-  * Made it possible to create a data volume 
+  * Made it possible to create a data volume
   * Made it possible to specify volumes-from in a container
   * Made it possible to copy data containers
   * Escape spaces from input forms
-  * Improved error handling for the Docker repo grid 
+  * Improved error handling for the Docker repo grid
 
  -- OpenMediaVault Plugin Developers <plugins@omv-extras.org>  Sun, 30 Aug 2015 07:09:25 +0200
 
@@ -318,7 +324,7 @@ openmediavault-docker-gui (0.2.2) unstable; urgency=low
 
 openmediavault-docker-gui (0.2.1) unstable; urgency=low
 
-  * Added license information 
+  * Added license information
   * Code refactoring
   * Prepare for translations
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,8 +1,8 @@
-openmediavault-docker-gui (4.0.2) UNRELEASED; urgency=medium
+openmediavault-docker-gui (4.0.2) zesty; urgency=medium
 
   * Fix for broken logo URLs
 
- -- OpenMediaVault Plugin Developers <plugins@omv-extras.org>  Fri, 12 Jan 2018 19:25:10 +0100
+ -- OpenMediaVault Plugin Developers <plugins@omv-extras.org>  Fri, 12 Jan 2018 21:20:50 +0100
 
 openmediavault-docker-gui (4.0.1) stable; urgency=low
 

--- a/usr/share/openmediavault/engined/rpc/docker.inc
+++ b/usr/share/openmediavault/engined/rpc/docker.inc
@@ -1501,12 +1501,16 @@ class OMVRpcServiceDocker extends ServiceAbstract
                     $old_hash = trim(file_get_contents($local_hash_path));
                 }
                 if (strcmp($new_hash, $old_hash) !== 0) {
-                    $imagick = new Imagick($logo_url);
-                    $imagick->scaleImage(40, 40, true);
-                    $imagick->modulateImage(100, 0, 100);
-                    $imagick->writeImage($local_logo_path . $logo_name);
-                    $imagick->clear();
-                    file_put_contents($local_hash_path, $new_hash);
+                    try {
+                        $imagick = new Imagick($logo_url);
+                        $imagick->scaleImage(40, 40, true);
+                        $imagick->modulateImage(100, 0, 100);
+                        $imagick->writeImage($local_logo_path . $logo_name);
+                        $imagick->clear();
+                        file_put_contents($local_hash_path, $new_hash);
+                    } catch (ImagickException $e) {
+                        //Do nothing
+                    }
                 }
             }
         }
@@ -1704,7 +1708,7 @@ class OMVRpcServiceDocker extends ServiceAbstract
     }
 
     //throw new OMVModuleDockerException($cmd);
-    
+
     /**
      * Connect the selected container to a specific docker network
      *


### PR DESCRIPTION
This should fix the issue when an image in the Repo tab uses a logo that isn't available. The solution is to simply skip such images.