### PR TITLE
Fetch port bindings from NetworkSettings->Ports instead of HostConfig

### DIFF
--- a/usr/share/omvdocker/Container.php
+++ b/usr/share/omvdocker/Container.php
@@ -279,8 +279,8 @@ class OMVModuleDockerContainer
         }
         $this->_imageId = substr($containerData->Image, 7);
         $this->_portBindings = array();
-        if (isset($containerData->HostConfig->PortBindings)) {
-            foreach ($containerData->HostConfig->PortBindings as $containerPort => $mappings) {
+        if (isset($containerData->NetworkSettings->Ports)) {
+            foreach ($containerData->NetworkSettings->Ports as $containerPort => $mappings) {
                 foreach ($mappings as $mapping) {
                     array_push(
                         $this->_portBindings,


### PR DESCRIPTION
This is a fix for https://forum.openmediavault.org/index.php/Thread/21465-docker-modify-machine-forgets-paramters/

This should be backported to 3.x as bug fix