### PR TITLE
Add the file log size for the container grid.

### DIFF
--- a/usr/share/omvdocker/Container.php
+++ b/usr/share/omvdocker/Container.php
@@ -351,8 +351,6 @@ class OMVModuleDockerContainer
         }
 
         $this->_logPath = $containerData->LogPath;
-        //$logPath = $containerData->LogPath;
-        //print $logPath;
 
         $this->_hostName = "";
         if (!(strcmp($containerData->Config->Hostname, "") === 0)) {

--- a/usr/share/openmediavault/engined/rpc/docker.inc
+++ b/usr/share/openmediavault/engined/rpc/docker.inc
@@ -426,8 +426,22 @@ class OMVRpcServiceDocker extends ServiceAbstract
         $objects = array();
         $settings=$this->database->getAssoc($this->dataModelPath);
 
+        // Determine if the user is using a non-default docker datarootpath
+        if (!empty($settings['sharedfolderref'])) {
+            $datarootpath = Rpc::call(
+                "ShareMgmt",
+                "getPath",
+                array(
+                    "uuid" => $settings['sharedfolderref']
+                ),
+                $context
+            );
+        } else {
+            $datarootpath = "/var/lib/docker";
+        }
+
         if ($settings['enabled']) {
-            $objects = OMVModuleDockerUtil::getContainerList();
+            $objects = OMVModuleDockerUtil::getContainerList($datarootpath);
         }
         return $objects;
     }

--- a/var/www/openmediavault/js/omv/module/admin/service/docker/ContainerGrid.js
+++ b/var/www/openmediavault/js/omv/module/admin/service/docker/ContainerGrid.js
@@ -101,6 +101,13 @@ Ext.define("OMV.module.admin.service.docker.ContainerGrid", {
         stateId: 'state',
         filter: 'list'
     },{
+        xtype: "binaryunitcolumn",
+        text: _("LOG SIZE"),
+        dataIndex: 'logsize',
+        sortable: true,
+        stateId: 'logsize',
+        filter: 'list'
+    },{
         xtype: "textcolumn",
         text: _("EXTRA ARGUMENTS"),
         dataIndex: 'extraargs',
@@ -146,7 +153,8 @@ Ext.define("OMV.module.admin.service.docker.ContainerGrid", {
                         { name: "hostname", type: "string" },
                         { name: "timesync", type: "boolean" },
                         { name: "imagevolumes", type: "array" },
-                        { name: "containercommand", type: "string" }
+                        { name: "containercommand", type: "string" },
+                        { name: "logsize", type: "integer" }
                     ]
                 }),
                 proxy: {


### PR DESCRIPTION
Some containers logs can get big in size while running. This can help users to select which containers can have their logs cleared.